### PR TITLE
since-3.7: Switch to a no-op that doesn’t interfere with type hints

### DIFF
--- a/since-3.7.py
+++ b/since-3.7.py
@@ -1,4 +1,3 @@
-# XXX Beware that if you use type hints,
-# this will become no-op only in Python 3.11.
-
-from __future__ import annotations  # Python >= 3.7 is required
+if 0:
+    async def f(x):
+        f"{await x}"  # Python >= 3.7 is required


### PR DESCRIPTION
```python3
if 0:
    async def f(x):
        f"{await x}"  # Python >= 3.7 is required
```